### PR TITLE
Add pagination to blog

### DIFF
--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -1,0 +1,102 @@
+---
+interface Props {
+    total: number;
+    current: number;
+}
+
+const { total, current } = Astro.props;
+
+const pages = Array.from({ length: total }, (_, i) => i + 1);
+---
+
+<div class="pagination">
+    {
+        current > 1 && (
+            <a href={`?page=${current - 1}`} class="pagination-link prev">
+                <svg width="25px" height="25px" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                        d="M6 4a1 1 0 011 1v10a1 1 0 11-2 0V5a1 1 0 011-1zm7.219.376a1 1 0 111.562 1.249L11.28 10l3.5 4.375a1 1 0 11-1.562 1.249l-4-5a1 1 0 010-1.25l4-5z"
+                        fill="currentColor"
+                    />
+                </svg>
+            </a>
+        )
+    }
+
+    <div class="pagination-numbers">
+        {
+            pages.map((page) => {
+                if (page - 1 === current || page === current || page + 1 === current) {
+                    return (
+                        <a href={`?page=${page}`} class:list={["pagination-link", { active: page === current }]}>
+                            {page}
+                        </a>
+                    );
+                }
+                return null;
+            })
+        }
+    </div>
+
+    {
+        current < total && (
+            <a href={`?page=${current + 1}`} class="pagination-link next">
+                <svg width="25px" height="25px" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                        d="M14 4a1 1 0 011 1v10a1 1 0 11-2 0V5a1 1 0 011-1zm-7.219.376l4 5a1 1 0 010 1.249l-4 5a1 1 0 11-1.562-1.25l3.5-4.374-3.5-4.376a1 1 0 111.562-1.25z"
+                        fill="current"
+                    />
+                </svg>
+            </a>
+        )
+    }
+</div>
+
+<style>
+    .pagination {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 1rem;
+        margin: 2rem 0;
+    }
+
+    .pagination-numbers {
+        display: flex;
+        gap: 0.5rem;
+    }
+
+    .pagination-link {
+        padding: 0.5rem 1rem;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        text-decoration: none;
+        color: #333;
+        transition: all 0.2s ease;
+        text-align: center;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .pagination-link:hover {
+        background-color: #f0f0f0;
+    }
+
+    .pagination-link.active {
+        background-color: #333;
+        color: white;
+        border-color: #333;
+    }
+
+    .prev,
+    .next {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 2rem;
+        height: 2rem;
+        border-radius: 4px;
+        border: 1px solid #ddd;
+    }
+</style>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -4,6 +4,8 @@
 export const SITE_TITLE = 'CROBF';
 export const SITE_DESCRIPTION = 'Empresa de desarrollo de software';
 
+export const PAGINATION_SIZE = 7;
+
 export const TEAM_MEMBERS = {
   Juan: {
     fullName: "Beresiarte Juan",

--- a/src/pages/[lang]/blog/index.astro
+++ b/src/pages/[lang]/blog/index.astro
@@ -3,17 +3,12 @@ import { SITE_TITLE, SITE_DESCRIPTION } from "../../../consts";
 import { getCollection } from "astro:content";
 import FormattedDate from "../../../components/FormattedDate.astro";
 import Layout from "../../../layouts/Layout.astro";
+import Pagination from "../../../components/Pagination.astro";
+import { PAGINATION_SIZE } from "../../../consts";
 
-export function getStaticPaths() {
-    return [
-        {
-            params: { lang: "es" },
-        },
-        {
-            params: { lang: "en" },
-        },
-    ];
-}
+export const prerender = false;
+
+const actualPage: number = Number(Astro.url.searchParams.get("page")) || 1;
 
 const lang = Astro.params.lang;
 
@@ -33,26 +28,29 @@ const posts = (await getCollection("blog"))
         <section>
             <ul>
                 {
-                    posts.map((post) => (
-                        <li>
-                            <a href={`/${lang}/blog${post.slug.slice(2)}/`}>
-                                <img
-                                    width={720}
-                                    height={360}
-                                    src={post.data.heroImage}
-                                    alt=""
-                                    style="object-fit: cover; width: 100%; height: 100%;"
-                                />
-                                <h4 class="title">{post.data.title}</h4>
-                                <p class="date">
-                                    <FormattedDate date={post.data.pubDate} />
-                                </p>
-                            </a>
-                        </li>
-                    ))
+                    posts
+                        .slice((actualPage - 1) * PAGINATION_SIZE, (actualPage - 1) * PAGINATION_SIZE + PAGINATION_SIZE)
+                        .map((post) => (
+                            <li>
+                                <a href={`/${lang}/blog${post.slug.slice(2)}/`}>
+                                    <img
+                                        width={720}
+                                        height={360}
+                                        src={post.data.heroImage}
+                                        alt=""
+                                        style="object-fit: cover; width: 100%; height: 100%;"
+                                    />
+                                    <h4 class="title">{post.data.title}</h4>
+                                    <p class="date">
+                                        <FormattedDate date={post.data.pubDate} />
+                                    </p>
+                                </a>
+                            </li>
+                        ))
                 }
             </ul>
         </section>
+        <Pagination total={Math.ceil(posts.length / PAGINATION_SIZE)} current={actualPage} />
     </main>
 
     <style>


### PR DESCRIPTION
### feat(blog): Add pagination to blog posts

### Description  
Esta PR añade paginación a la sección del blog para mejorar la navegación y la experiencia del usuario cuando hay una gran cantidad de publicaciones. Los cambios incluyen:  
- La creación de un componente `Pagination.astro` reutilizable.  
- La integración de la paginación en la página del blog (`[lang]/blog/index.astro`).  
- La configuración de un tamaño de paginación definido en las constantes (`PAGINATION_SIZE`).  

---

### Changes  

- **Added:**  
  - Nuevo componente `Pagination.astro` para manejar la navegación entre páginas.  
  - Constante `PAGINATION_SIZE` en `src/consts.ts` para definir el número de publicaciones por página.  

- **Updated:**  
  - Página del blog (`[lang]/blog/index.astro`) para soportar paginación y mostrar solo las publicaciones correspondientes a la página actual.  

- **Fixed:**  
  - Mejora en la organización del código para manejar la lógica de paginación de manera eficiente.  

---

### Notes for Reviewers  

- **Cambios principales**:  
  - El componente `Pagination.astro` es reutilizable y puede adaptarse a otras secciones que requieran paginación.  
  - La lógica de paginación se implementó utilizando el parámetro `page` en la URL (`?page=1`).  

- **Impacto**:  
  - Estos cambios no afectan la funcionalidad existente, pero mejoran la experiencia del usuario al navegar por el blog.  